### PR TITLE
Clarify that autodetect only defaults to true if 'requirements' not set

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -126,7 +126,7 @@ The currently supported frameworks are ``celery`` and ``django``.
 ----------------------
 
 The default behaviour is to autodetect dependencies in order to augment the code analysis. This
-setting can be used to turn off autodetection completely. The default value is ``true``.
+setting can be used to turn off autodetection completely. The default value is ``true``, unless ``requirements`` has been defined.
 The value can be 'true' or 'false'.
 
 


### PR DESCRIPTION
Fixes landscapeio/landscape-issues#117.
