### PR TITLE
fixed link in using-landscape.rst

### DIFF
--- a/using-landscape.rst
+++ b/using-landscape.rst
@@ -57,7 +57,7 @@ If Using Flask
 --------------
 
 Similarly, Landscape has Flask-specific behaviours thanks to the awesome
-`pylint-flask plugin<https://github.com/jschaf/pylint-flask>`_.
+`pylint-flask plugin <https://github.com/jschaf/pylint-flask>`_.
 
 
 What Next?


### PR DESCRIPTION
before:

```
`pylint-flask plugin<https://github.com/jschaf/pylint-flask>`_.
```

now:

```
pylint-flask plugin
```
